### PR TITLE
Update access token expiration window (24h)

### DIFF
--- a/backend/main_module/settings.py
+++ b/backend/main_module/settings.py
@@ -141,7 +141,7 @@ STATIC_URL = 'static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 SIMPLE_JWT = {
-    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=30),
+    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=1440),
     'REFRESH_TOKEN_LIFETIME': timedelta(days=1),
 }
 


### PR DESCRIPTION
This PR extends the expiration window of the JWT token acquired through the `/api/v1/login` endpoint