### PR TITLE
Set id field setting for simple jwt

### DIFF
--- a/backend/main_module/settings.py
+++ b/backend/main_module/settings.py
@@ -166,6 +166,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 SIMPLE_JWT = {
 #    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=1440),
+    'USER_ID_FIELD': 'login',
     'REFRESH_TOKEN_LIFETIME': timedelta(days=1),
     'ROTATE_REFRESH_TOKENS': True
 }


### PR DESCRIPTION
This PR fixes the problem introduced by the edition of user model fields where SimpleJWT couldn't determine what the new username field is. 