### PR TITLE
Hotfix: Add password hashing on update

### DIFF
--- a/backend/user_management/views.py
+++ b/backend/user_management/views.py
@@ -34,6 +34,7 @@ class UsuarioViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated, UserTypePermission]
     queryset = Usuario.objects.all()
     serializer_class = UsuarioSerializer
+    http_method_names = ['get', 'post', 'put', 'patch', 'delete']
 
     def create(self, request, *args, **kwargs):
         # Get the data from the request
@@ -50,5 +51,21 @@ class UsuarioViewSet(viewsets.ModelViewSet):
         headers = self.get_success_headers(serializer.data)
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
 
+    def update(self, request, *args, **kwargs):
+        partial = kwargs.pop('partial', True)
+        instance = self.get_object()
+        serializer = self.get_serializer(instance, data=request.data, partial=partial)
+        serializer.is_valid(raise_exception=True)
 
+        # Hash the new password if it's provided
+        password = request.data.get('password')
+        if password:
+            serializer.validated_data['password'] = make_password(password)
+
+        self.perform_update(serializer)
+
+        if getattr(instance, '_prefetched_objects_cache', None):
+            instance._prefetched_objects_cache = {}
+
+        return Response(serializer.data)
 


### PR DESCRIPTION
This PR implements password hashing on update for user_management module. The previous behavior (update not hashing new password) was introduced due to auth model overrides and changes related to the user creation methods.